### PR TITLE
feat: add error log and update to useIntl

### DIFF
--- a/src/plugins/Plugin.jsx
+++ b/src/plugins/Plugin.jsx
@@ -5,10 +5,7 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { ErrorBoundary } from '@edx/frontend-platform/react';
-import {
-  injectIntl,
-  intlShape,
-} from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import {
   dispatchMountedEvent, dispatchReadyEvent, dispatchUnmountedEvent, useHostEvent,
@@ -17,16 +14,19 @@ import { PLUGIN_RESIZE } from './data/constants';
 import messages from './Plugins.messages';
 
 // TODO: create example-plugin-app/src/PluginOne.jsx for example of customizing errorFallback as part of APER-3042 https://2u-internal.atlassian.net/browse/APER-3042
-const ErrorFallbackDefault = ({ intl }) => (
-  <div>
-    <h2>
-      {intl.formatMessage(messages.unexpectedError)}
-    </h2>
-  </div>
-);
+const ErrorFallbackDefault = () => {
+  const { formatMessage } = useIntl();
+  return (
+    <div>
+      <h2>
+        {formatMessage(messages.unexpectedError)}
+      </h2>
+    </div>
+  );
+};
 
 const Plugin = ({
-  children, className, style, ready, ErrorFallbackComponent, intl,
+  children, className, style, ready, ErrorFallbackComponent,
 }) => {
   const [dimensions, setDimensions] = useState({
     width: null,
@@ -68,7 +68,7 @@ const Plugin = ({
   return (
     <div className={className} style={finalStyle}>
       <ErrorBoundary
-        fallbackComponent={<ErrorFallback intl={intl} />}
+        fallbackComponent={<ErrorFallback />}
       >
         {children}
       </ErrorBoundary>
@@ -76,7 +76,7 @@ const Plugin = ({
   );
 };
 
-export default injectIntl(Plugin);
+export default Plugin;
 
 Plugin.propTypes = {
   /** The content for the Plugin */
@@ -89,8 +89,6 @@ Plugin.propTypes = {
   ready: PropTypes.bool,
   /** Styles to apply to the Plugin wrapper component */
   style: PropTypes.shape({}),
-  /** i18n  */
-  intl: intlShape.isRequired,
 };
 
 Plugin.defaultProps = {
@@ -98,8 +96,4 @@ Plugin.defaultProps = {
   ErrorFallbackComponent: null,
   style: {},
   ready: true,
-};
-
-ErrorFallbackDefault.propTypes = {
-  intl: intlShape.isRequired,
 };

--- a/src/plugins/PluginContainer.jsx
+++ b/src/plugins/PluginContainer.jsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import PropTypes from 'prop-types';
+import { logError } from '@edx/frontend-platform/logging';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import PluginContainerIframe from './PluginContainerIframe';
@@ -31,7 +33,8 @@ const PluginContainer = ({ config, ...props }) => {
       );
       break;
     default:
-      // istanbul ignore next: default isn't meaningful, just satisfying linter
+      logError(`Config type ${config.type} is not valid.`);
+      break;
   }
 
   return (
@@ -43,7 +46,7 @@ export default PluginContainer;
 
 PluginContainer.propTypes = {
   /** Configuration for the Plugin in this container — i.e pluginSlot[id].example_plugin */
-  config: pluginConfigShape,
+  config: PropTypes.shape(pluginConfigShape),
 };
 
 PluginContainer.defaultProps = {

--- a/src/plugins/PluginContainerDirect.jsx
+++ b/src/plugins/PluginContainerDirect.jsx
@@ -17,7 +17,7 @@ const PluginContainerDirect = ({ config, loadingFallback, ...props }) => {
 
 PluginContainerDirect.propTypes = {
   /** Configuration for the Plugin in this container (i.e. pluginSlot[id].example_plugin) */
-  config: directPluginConfigShape,
+  config: PropTypes.shape(directPluginConfigShape),
   /** Custom fallback component used when component is not ready (i.e. "loading") */
   loadingFallback: PropTypes.node,
 };

--- a/src/plugins/PluginContainerIframe.jsx
+++ b/src/plugins/PluginContainerIframe.jsx
@@ -84,7 +84,7 @@ export default PluginContainerIframe;
 
 PluginContainerIframe.propTypes = {
   /** Configuration for the Plugin in this container (i.e. pluginSlot[id].example_plugin) */
-  config: iframePluginConfigShape,
+  config: PropTypes.shape(iframePluginConfigShape),
   /** Custom fallback component used when component is not ready (i.e. "loading") */
   loadingFallback: PropTypes.node,
   /** Classes to apply to the iframe */

--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -5,8 +5,7 @@ import classNames from 'classnames';
 import { Spinner } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import {
-  injectIntl,
-  intlShape,
+  useIntl,
 } from '@edx/frontend-platform/i18n';
 
 import messages from './Plugins.messages';
@@ -15,23 +14,26 @@ import PluginContainer from './PluginContainer';
 import { organizePlugins, wrapComponent } from './data/utils';
 
 const PluginSlot = forwardRef(({
-  as, id, intl, pluginProps, ...props
+  as, id, pluginProps, ...props
 }, ref) => {
   /** TODO: Examples still need to be set up as part of APER-3042 https://2u-internal.atlassian.net/browse/APER-3042 */
   /* the plugins below are obtained by the id passed into PluginSlot by the Host MFE. See example/src/PluginsPage.jsx
   for an example of how PluginSlot is populated, and example/src/index.jsx for a dummy JS config that holds all plugins
   */
+
+  const { formatMessage } = useIntl();
+
   const { plugins, defaultContents } = usePluginSlot(id);
 
   const finalPlugins = React.useMemo(() => organizePlugins(defaultContents, plugins), [defaultContents, plugins]);
 
-  // TODO: APER-3178 — Find a better way to do pluginProps so that each plugin can have it's own unique props
+  // TODO: APER-3178 — Unique plugin props
   // https://2u-internal.atlassian.net/browse/APER-3178
   const { loadingFallback } = pluginProps;
 
   const defaultLoadingFallback = (
     <div className={classNames(pluginProps.className, 'd-flex justify-content-center align-items-center')}>
-      <Spinner animation="border" screenReaderText={intl.formatMessage(messages.loading)} />
+      <Spinner animation="border" screenReaderText={formatMessage(messages.loading)} />
     </div>
   );
 
@@ -54,10 +56,12 @@ const PluginSlot = forwardRef(({
         );
         // If wrappers are provided, wrap the Plugin
         if (pluginConfig.wrappers) {
-          finalChildren.push(wrapComponent(
-            () => newContainer,
-            pluginConfig.wrappers,
-          ));
+          finalChildren.push(
+            wrapComponent(
+              () => newContainer,
+              pluginConfig.wrappers,
+            ),
+          );
         } else {
           finalChildren.push(newContainer);
         }
@@ -75,15 +79,13 @@ const PluginSlot = forwardRef(({
   );
 });
 
-export default injectIntl(PluginSlot);
+export default PluginSlot;
 
 PluginSlot.propTypes = {
   /** Element type for the PluginSlot wrapper component */
   as: PropTypes.elementType,
   /** ID of the PluginSlot configuration */
   id: PropTypes.string.isRequired,
-  /** i18n  */
-  intl: intlShape.isRequired,
   /** Props that are passed down to each Plugin in the Slot */
   pluginProps: PropTypes.object, // eslint-disable-line
 };

--- a/src/plugins/data/hooks.js
+++ b/src/plugins/data/hooks.js
@@ -9,13 +9,13 @@ import { getConfig } from '@edx/frontend-platform';
 import { PLUGIN_MOUNTED, PLUGIN_READY, PLUGIN_UNMOUNTED } from './constants';
 
 /**
- * Called by PluginSlot to extract a list of plugins based on the JS configuration
+ * Called by PluginSlot to extract a list of plugins from the JS configuration
  *
  * @param {String} id - Name of PluginSlot
  * @returns {Object} - JS configuration for the PluginSlot
  */
 export function usePluginSlot(id) {
-  if (getConfig().pluginSlots[id] !== undefined) {
+  if (getConfig().pluginSlots?.[id] !== undefined) {
     return getConfig().pluginSlots[id];
   }
   return { plugins: [], defaultContents: [] };

--- a/src/plugins/data/shapes.js
+++ b/src/plugins/data/shapes.js
@@ -3,27 +3,27 @@
 import PropTypes from 'prop-types';
 import { DIRECT_PLUGIN, IFRAME_PLUGIN } from './constants';
 
-export const pluginConfigShape = PropTypes.shape({
+export const pluginConfigShape = {
   /** Id for the plugin */
   id: PropTypes.string.isRequired,
   /** Plugin type */
   type: PropTypes.oneOf([IFRAME_PLUGIN, DIRECT_PLUGIN]).isRequired,
   /** Priority of the plugin — ordered low-to-high */
   priority: PropTypes.number,
-});
+};
 
-export const iframePluginConfigShape = PropTypes.shape({
+export const iframePluginConfigShape = {
   ...pluginConfigShape,
   /** URL for the iframe src */
   url: PropTypes.string.isRequired,
   /** Title attribute for the iframe */
   title: PropTypes.string.isRequired,
-});
+};
 
-export const directPluginConfigShape = PropTypes.shape({
+export const directPluginConfigShape = {
   ...pluginConfigShape,
   /** Component that receives id and content as props */
   RenderWidget: PropTypes.func.isRequired,
   /** Content that is passed to the RenderWidget function */
   content: PropTypes.object,
-});
+};


### PR DESCRIPTION
This adds error logging for when an invalid configuration type is provided to the `PluginContainer`. 

The `intl` object has also been replaced in both `PluginSlot` and `Plugin` to now use the `useIntl` hook. 

The `shapes.jsx` file has been updated as well as how the shapes are used in their respective components. This cleans up a warning we were seeing around configs being undefined. This was caused by `Proptypes.shape()` being used on a config that was also wrapped in `Proptypes.shape()` so it ended up reading 
```
PropTypes.shape(PropTypes.shape({...configObject})
``` 
rather than 
```
PropTypes.shape({...configObject})
```