### PR TITLE
fix: PluginSlot default to Fragment

### DIFF
--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -106,7 +106,7 @@ PluginSlot.propTypes = {
 };
 
 PluginSlot.defaultProps = {
-  as: 'div',
+  as: React.Fragment,
   children: null,
   pluginProps: {},
 };

--- a/src/plugins/PluginSlot.test.jsx
+++ b/src/plugins/PluginSlot.test.jsx
@@ -53,6 +53,7 @@ const TestPluginSlot = (
     <PluginSlot
       id="test-slot"
       data-testid="test-slot-id"
+      as="div"
     >
       <div data-testid="default_contents">
         {content.text}


### PR DESCRIPTION
This changes the default element for PluginSlot to be a React.Fragment. This makes sure that the wrapping element doesn't interfere with CSS and the page layout.

Devs can still set the `as` property to pass any valid React component `type` to the PluginSlot and that will set the wrapping element accordingly ([React docs on valid types](https://react.dev/reference/react/createElement#parameters)).