### PR TITLE
chore: add validation to plugin configuration

### DIFF
--- a/src/plugins/PluginContainer.jsx
+++ b/src/plugins/PluginContainer.jsx
@@ -33,7 +33,6 @@ function PluginContainer({ config, ...props }) {
       );
       break;
     default:
-      logError(`Config type ${config.type} is not valid.`);
       break;
   }
 

--- a/src/plugins/PluginContainer.jsx
+++ b/src/plugins/PluginContainer.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { logError } from '@edx/frontend-platform/logging';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import PluginContainerIframe from './PluginContainerIframe';

--- a/src/plugins/PluginSlot.test.jsx
+++ b/src/plugins/PluginSlot.test.jsx
@@ -7,9 +7,10 @@ import { logError } from '@edx/frontend-platform/logging';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import PluginSlot from './PluginSlot';
 import { usePluginSlot } from './data/hooks';
+import { PLUGIN_OPERATIONS } from './data/constants';
 
 const iframePluginConfig = {
-  op: 'insert',
+  op: PLUGIN_OPERATIONS.Insert,
   widget: {
     id: 'iframe_config',
     url: 'http://localhost/plugin1',
@@ -103,7 +104,7 @@ describe('PluginSlot', () => {
     usePluginSlot.mockReturnValueOnce({
       plugins: [
         {
-          op: 'wrap',
+          op: PLUGIN_OPERATIONS.Wrap,
           widgetId: 'default_contents',
           wrapper: ({ component, idx }) => (
             <div key={idx} data-testid={`wrapper${idx + 1}`}>
@@ -127,7 +128,7 @@ describe('PluginSlot', () => {
       plugins: [
         iframePluginConfig,
         {
-          op: 'hide',
+          op: PLUGIN_OPERATIONS.Hide,
           widgetId: 'iframe_config',
         },
       ],
@@ -143,7 +144,7 @@ describe('PluginSlot', () => {
     usePluginSlot.mockReturnValueOnce({
       plugins: [
         {
-          op: 'insert',
+          op: PLUGIN_OPERATIONS.Insert,
           widget: {
             id: 'invalid_config',
             type: 'INVALID_TYPE',
@@ -154,6 +155,6 @@ describe('PluginSlot', () => {
     });
     render(TestPluginSlot);
 
-    expect(logError).toHaveBeenCalledWith('Config type INVALID_TYPE is not valid.');
+    expect(logError).toHaveBeenCalledWith('the insert operation config is invalid for widget id: invalid_config');
   });
 });

--- a/src/plugins/data/constants.js
+++ b/src/plugins/data/constants.js
@@ -22,3 +22,31 @@ export const PLUGIN_OPERATIONS = {
   Modify: 'modify',
   Wrap: 'wrap',
 };
+
+export const requiredPluginTypes = {
+  insert: {
+    base: {
+      id: 'string',
+      priority: 'number',
+      type: 'string',
+    },
+    direct_plugin: {
+      RenderWidget: 'function',
+    },
+    iframe_plugin: {
+      title: 'string',
+      url: 'string',
+    },
+  },
+  hide: {
+    widgetId: 'string',
+  },
+  modify: {
+    widgetId: 'string',
+    fn: 'function',
+  },
+  wrap: {
+    widgetId: 'string',
+    wrapper: 'function',
+  },
+};

--- a/src/plugins/data/hooks.test.jsx
+++ b/src/plugins/data/hooks.test.jsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { getConfig } from '@edx/frontend-platform';
 import { usePluginSlot } from './hooks';
 
-import { PLUGIN_OPERATIONS } from './constants';
+import { IFRAME_PLUGIN, PLUGIN_OPERATIONS } from './constants';
 
 const mockSlotChanges = [
   {
@@ -10,9 +10,9 @@ const mockSlotChanges = [
     widget: {
       id: 'login',
       priority: 50,
-      content: {
-        url: '/login', label: 'Login',
-      },
+      type: IFRAME_PLUGIN,
+      url: '/login',
+      title: 'Login',
     },
   },
 ];

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -1,6 +1,43 @@
 import React from 'react';
 import { getConfig } from '@edx/frontend-platform';
-import { PLUGIN_OPERATIONS, DIRECT_PLUGIN, IFRAME_PLUGIN } from './constants';
+import { logError } from '@edx/frontend-platform/logging';
+import { PLUGIN_OPERATIONS, requiredPluginTypes } from './constants';
+
+/**
+ * Called by validatePlugin to compare plugin config to the required data and data types
+ * @returns {Boolean} - returns true if all types are correct and present according to the plugin operation
+ */
+const validateRequirements = (requiredTypes, widgetConfig) => (Object.keys(requiredTypes).every(
+  // eslint-disable-next-line valid-typeof
+  (field) => (widgetConfig[field] && (typeof widgetConfig[field] === requiredTypes[field])),
+));
+
+/**
+ * Called by organizePlugins to validate plugin configurations
+ * @returns {Boolean} - boolean if all types are correct and present, else throws an error
+ */
+export const validatePlugin = (pluginConfig) => {
+  let requiredTypes = {};
+  // eslint-disable-next-line prefer-const
+  let { op, ...config } = pluginConfig;
+
+  if (op === PLUGIN_OPERATIONS.Insert) {
+    config = config.widget;
+    if (!config) { logError('insert operation config is missing widget object'); }
+
+    requiredTypes = {
+      ...requiredPluginTypes[op].base,
+      ...requiredPluginTypes[op][config.type?.toLowerCase()],
+    };
+  } else {
+    requiredTypes = requiredPluginTypes[op];
+  }
+
+  if (!validateRequirements(requiredTypes, config)) {
+    logError(`the ${op || 'INVALID'} operation config is invalid for widget id: ${config.widgetId || config.id || 'MISSING ID'}`);
+  }
+  return true;
+};
 
 /**
  * Called by PluginSlot to prepare the plugin changes for the given slot
@@ -13,6 +50,7 @@ export const organizePlugins = (defaultContents, plugins) => {
   const newContents = [...defaultContents];
 
   plugins.forEach(change => {
+    validatePlugin(change);
     if (change.op === PLUGIN_OPERATIONS.Insert) {
       newContents.push(change.widget);
     } else if (change.op === PLUGIN_OPERATIONS.Hide) {
@@ -59,121 +97,6 @@ export const wrapComponent = (renderComponent, wrappers) => wrappers.reduce(
  * @returns {Object} - The pluginSlots object in Config Document
  */
 export const getConfigSlots = () => getConfig()?.pluginSlots;
-
-// TODO: validating plugin operations. likely use combination of Object.keys to
-// check each key and typeof to check each property's type
-// consider: storing config shapes in shapes.js, writing a util function validatePlugin
-// that gets called for each operation here
-// write tests for validatePlugin
-// on error, validatePlugin throws typeError with message of plugin id
-
-/* Insert must include the following configuration
-  widget: {
-    id: 'new_plugin',
-    priority: 10,
-    type: DIRECT_PLUGIN,
-    RenderWidget: SomeComponent
-  }
-
-  widget: {
-    id: 'iframe_plugin',
-    priority: 10,
-    type: IFRAME_PLUGIN
-    title: 'iframe plugin',
-    url: 'example.url.com'
-  }
-
-  widget: {
-    id: 'inserted_plugin',
-    type: DIRECT_PLUGIN,
-    priority: 10,
-    RenderWidget: ModularComponent,
-    content: {
-      title: 'Modular Direct Plugin',
-      uniqueText: 'This is some text that will be replaced by the Modify operation below.',
-    },
-  },
-*/
-
-/* Hide must include the following configuration
-  widgetId,
-*/
-
-/* Modify must include the following configuration
-  widgetId,
-  fn
-*/
-
-/* Wrap must include the following configuration
-  widget: {
-    id: 'new_plugin',
-    priority: 10,
-    type: DIRECT_PLUGIN,
-    RenderWidget: SomeComponent
-  }
-*/
-
-const validateRequirements = (requiredTypes, widgetConfig) => (Object.keys(requiredTypes).every(
-  (field) => (widgetConfig[field] && (typeof widgetConfig[field] === requiredTypes[field])),
-));
-
-export const validatePlugin = (pluginConfig) => {
-  let isValidConfig = true;
-  const { op, ...config } = pluginConfig;
-
-  if (op === PLUGIN_OPERATIONS.Insert) {
-    const { widget = undefined } = config;
-    const requiredTypes = {
-      base: {
-        id: 'string',
-        priority: 'number',
-        type: 'string',
-      },
-      direct_plugin: {
-        RenderWidget: 'function',
-      },
-      iframe_plugin: {
-        title: 'string',
-        url: 'string',
-      },
-    };
-
-    const plugins = [DIRECT_PLUGIN, IFRAME_PLUGIN];
-    if (!widget) { throw new Error('plugin configuration is missing widget object'); }
-    if (!plugins.includes(widget.type)) { throw new Error(`${op} configuration for widget id (${widget.id}) has unknown plugin type or it is missing`); }
-    if (!requiredTypes[widget.type.toLowerCase()]) {
-      throw new Error(`${op} configuration for widget id (${widget.id}) has unknown plugin type or it is missing`);
-    }
-
-    isValidConfig = validateRequirements({ ...requiredTypes.base, ...requiredTypes[widget.type.toLowerCase()] }, widget);
-
-    if (!isValidConfig) { throw new Error(`${op} configuration is invalid for ${widget.type} with widget id: ${widget.id || 'MISSING ID'}`); }
-  } else if (op === PLUGIN_OPERATIONS.Hide) {
-    const requiredTypes = {
-      widgetId: 'string',
-    };
-
-    isValidConfig = validateRequirements(requiredTypes, config);
-    if (!isValidConfig) { throw new Error(`the ${op} operation is missing a widgetId`); }
-  } else if (op === PLUGIN_OPERATIONS.Modify) {
-    const requiredTypes = {
-      widgetId: 'string',
-      fn: 'function',
-    };
-
-    isValidConfig = validateRequirements(requiredTypes, config);
-    if (!isValidConfig) { throw new Error(`the ${op} configuration is invalid for widget id: ${config.widgetId || 'MISSING ID'}`); }
-  } else if (op === PLUGIN_OPERATIONS.Wrap) {
-    const requiredTypes = {
-      widgetId: 'string',
-      wrapper: 'function',
-    };
-
-    isValidConfig = validateRequirements(requiredTypes, config);
-    if (!isValidConfig) { throw new Error(`the ${op} configuration is invalid for widget id: ${config.widgetId || 'MISSING ID'}`); }
-  }
-  return isValidConfig;
-};
 
 export default {
   getConfigSlots,

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -32,7 +32,7 @@ export const organizePlugins = (defaultContents, plugins) => {
         newContents[widgetIdx] = newWidget;
       }
     } else {
-      throw new Error('unknown direct plugin change operation');
+      throw new Error('unknown plugin change operation');
     }
   });
 
@@ -60,8 +60,78 @@ export const wrapComponent = (renderComponent, wrappers) => wrappers.reduce(
  */
 export const getConfigSlots = () => getConfig()?.pluginSlots;
 
+// TODO: validating plugin operations. likely use combination of Object.keys to check each key and typeof to check each property's type
+// consider: storing config shapes in shapes.js, writing a util function validatePlugin that gets called for each operation here
+// write tests for validatePlugin
+// on error, validatePlugin throws typeError with message of plugin id
+
+/* Insert must include the following configuration
+  widget: {
+    id: 'new_plugin',
+    priority: 10,
+    type: DIRECT_PLUGIN,
+    RenderWidget: SomeComponent
+  }
+
+  widget: {
+    id: 'iframe_plugin',
+    priority: 10,
+    type: IFRAME_PLUGIN
+    title: 'iframe plugin',
+    url: 'example.url.com'
+  }
+
+  widget: {
+    id: 'inserted_plugin',
+    type: DIRECT_PLUGIN,
+    priority: 10,
+    RenderWidget: ModularComponent,
+    content: {
+      title: 'Modular Direct Plugin',
+      uniqueText: 'This is some text that will be replaced by the Modify operation below.',
+    },
+  },
+*/
+
+/* Hide must include the following configuration
+  widgetId,
+*/
+
+/* Modify must include the following configuration
+  widgetId,
+  fn
+*/
+
+/* must include the following configuration
+  widget: {
+    id: 'new_plugin',
+    priority: 10,
+    type: DIRECT_PLUGIN,
+    RenderWidget: SomeComponent
+  }
+*/
+
+export const validatePlugin = ({ op, widget }) => {
+  if (op === PLUGIN_OPERATIONS.Insert) {
+    const requiredFields = ['id', 'priority', 'type'];
+    const requiredTypes = {
+      id: 'string',
+      priority: 'number',
+      type: 'string',
+      RenderWidget: 'function',
+      title: 'string',
+      url: 'string',
+      content: 'object',
+    };
+
+    const isValidField = requiredFields.every((field) => Object.keys(widget).includes(field));
+    const isValidTypes = Object.keys(widget).every((key) => typeof widget[key] === requiredTypes[key]);
+    return isValidField && isValidTypes;
+  }
+}
 export default {
   getConfigSlots,
   organizePlugins,
+  validatePlugin,
   wrapComponent,
 };

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -153,8 +153,24 @@ export const validatePlugin = (pluginConfig) => {
       widgetId: 'string',
     };
 
-    if (!config.widgetId) { throw new Error('the Hide operation is missing a widgetId'); }
     isValidConfig = validateRequirements(requiredTypes, config);
+    if (!isValidConfig) { throw new Error(`the ${op} operation is missing a widgetId`); }
+  } else if (op === PLUGIN_OPERATIONS.Modify) {
+    const requiredTypes = {
+      widgetId: 'string',
+      fn: 'function',
+    };
+
+    isValidConfig = validateRequirements(requiredTypes, config);
+    if (!isValidConfig) { throw new Error(`the ${op} configuration is invalid for widget id: ${config.widgetId || 'MISSING ID'}`); }
+  } else if (op === PLUGIN_OPERATIONS.Wrap) {
+    const requiredTypes = {
+      widgetId: 'string',
+      wrapper: 'function',
+    };
+
+    isValidConfig = validateRequirements(requiredTypes, config);
+    if (!isValidConfig) { throw new Error(`the ${op} configuration is invalid for widget id: ${config.widgetId || 'MISSING ID'}`); }
   }
   return isValidConfig;
 };

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -117,10 +117,12 @@ const validateRequirements = (requiredTypes, widgetConfig) => (Object.keys(requi
   (field) => (widgetConfig[field] && (typeof widgetConfig[field] === requiredTypes[field])),
 ));
 
-export const validatePlugin = ({ op, widget }) => {
+export const validatePlugin = (pluginConfig) => {
   let isValidConfig = true;
+  const { op, ...config } = pluginConfig;
 
   if (op === PLUGIN_OPERATIONS.Insert) {
+    const { widget = undefined } = config;
     const requiredTypes = {
       base: {
         id: 'string',
@@ -146,8 +148,15 @@ export const validatePlugin = ({ op, widget }) => {
     isValidConfig = validateRequirements({ ...requiredTypes.base, ...requiredTypes[widget.type.toLowerCase()] }, widget);
 
     if (!isValidConfig) { throw new Error(`${op} configuration is invalid for ${widget.type} with widget id: ${widget.id || 'MISSING ID'}`); }
-    return true;
+  } else if (op === PLUGIN_OPERATIONS.Hide) {
+    const requiredTypes = {
+      widgetId: 'string',
+    };
+
+    if (!config.widgetId) { throw new Error('the Hide operation is missing a widgetId'); }
+    isValidConfig = validateRequirements(requiredTypes, config);
   }
+  return isValidConfig;
 };
 
 export default {

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -20,6 +20,7 @@ export const validatePlugin = (pluginConfig) => {
   let requiredTypes = {};
   // eslint-disable-next-line prefer-const
   let { op, ...config } = pluginConfig;
+  if (!op) { logError('There is a config with an invalid PLUGIN_OPERATION. Check to make sure it is configured correctly.'); }
 
   if (op === PLUGIN_OPERATIONS.Insert) {
     config = config.widget;
@@ -34,7 +35,7 @@ export const validatePlugin = (pluginConfig) => {
   }
 
   if (!validateRequirements(requiredTypes, config)) {
-    logError(`the ${op || 'INVALID'} operation config is invalid for widget id: ${config.widgetId || config.id || 'MISSING ID'}`);
+    logError(`the ${op} operation config is invalid for widget id: ${config.widgetId || config.id || 'MISSING ID'}`);
   }
   return true;
 };
@@ -69,8 +70,6 @@ export const organizePlugins = (defaultContents, plugins) => {
         newWidget.wrappers.push(change.wrapper);
         newContents[widgetIdx] = newWidget;
       }
-    } else {
-      throw new Error('unknown plugin change operation');
     }
   });
 

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -173,21 +173,6 @@ describe('organizePlugins', () => {
       expect(plugins[1].id).toBe('default_contents');
       expect(plugins[2].id).toBe('login');
     });
-
-    it('should raise an error for an operation that does not exist', async () => {
-      const badPluginChange = {
-        op: PLUGIN_OPERATIONS.Destroy,
-        widgetId: 'drafts',
-      };
-      mockSlotChanges.push(badPluginChange);
-
-      expect.assertions(1);
-      try {
-        await organizePlugins(mockDefaultContent, mockSlotChanges);
-      } catch (error) {
-        expect(logError).toHaveBeenCalledWith('the INVALID operation config is invalid for widget id: drafts');
-      }
-    });
   });
 });
 
@@ -439,6 +424,20 @@ describe('validatePlugin', () => {
         validatePlugin(invalidWrapConfig2);
       } catch (error) {
         expect(logError).toHaveBeenCalledWith('the wrap operation config is invalid for widget id: MISSING ID');
+      }
+    });
+  });
+  describe('an invalid plugin configuration', () => {
+    it('should raise an error for an operation that does not exist', () => {
+      const invalidPluginConfig = {
+        op: PLUGIN_OPERATIONS.Destroy,
+        widgetId: 'drafts',
+      };
+
+      try {
+        validatePlugin(invalidPluginConfig);
+      } catch (error) {
+        expect(logError).toHaveBeenCalledWith('There is a config with an invalid PLUGIN_OPERATION. Check to make sure it is configured correctly.');
       }
     });
   });

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -251,45 +251,107 @@ describe('getConfigSlots', () => {
 });
 
 describe('validatePlugin', () => {
-  it('returns true if the plugin config is correctly configured', () => {
-    const insertDirectConfig = {
-      op: PLUGIN_OPERATIONS.Insert,
-      widget: {
-        id: 'new_plugin',
-        priority: 10,
-        type: DIRECT_PLUGIN,
-        RenderWidget: mockRenderWidget,
-      },
-    };
-    const insertIFrameConfig = {
-      op: PLUGIN_OPERATIONS.Insert,
-      widget: {
-        id: 'new_plugin',
-        priority: 10,
-        type: IFRAME_PLUGIN,
-        title: 'iframe plugin',
-        url: 'example.url.com',
-      },
-    };
-    const insertDirectModularConfig = {
-      op: PLUGIN_OPERATIONS.Insert,
-      widget: {
-        id: 'inserted_plugin',
-        type: DIRECT_PLUGIN,
-        priority: 10,
-        RenderWidget: mockRenderWidget,
-        content: {
-          title: 'Modular Direct Plugin',
-          uniqueText: 'This is some text.',
+  describe('insert plugin', () => {
+    it('returns true if the plugin config is correctly configured', () => {
+      const insertDirectConfig = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'new_plugin',
+          priority: 10,
+          type: DIRECT_PLUGIN,
+          RenderWidget: mockRenderWidget,
         },
-      },
-    };
+      };
+      const insertIFrameConfig = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'new_plugin',
+          priority: 10,
+          type: IFRAME_PLUGIN,
+          title: 'iframe plugin',
+          url: 'example.url.com',
+        },
+      };
+      const insertDirectModularConfig = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'inserted_plugin',
+          type: DIRECT_PLUGIN,
+          priority: 10,
+          RenderWidget: mockRenderWidget,
+          content: {
+            title: 'Modular Direct Plugin',
+            uniqueText: 'This is some text.',
+          },
+        },
+      };
 
-    expect(validatePlugin(insertDirectConfig)).toBe(true);
-    expect(validatePlugin(insertIFrameConfig)).toBe(true);
-    expect(validatePlugin(insertDirectModularConfig)).toBe(true);
-  });
-  it('returns false if the plugin config is incorrectly configured', () => {
+      expect(validatePlugin(insertDirectConfig)).toBe(true);
+      expect(validatePlugin(insertIFrameConfig)).toBe(true);
+      expect(validatePlugin(insertDirectModularConfig)).toBe(true);
+    });
 
+    it('returns false if the plugin config is incorrectly configured', () => {
+      // missing id for Direct Plugin
+      const insertBrokenDirectConfig = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          priority: 10,
+          type: DIRECT_PLUGIN,
+          RenderWidget: mockRenderWidget,
+        },
+      };
+      // missing RenderWidget for Direct Plugin
+      const insertBrokenDirectConfig2 = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'new_plugin',
+          priority: 10,
+          type: DIRECT_PLUGIN,
+        },
+      };
+      // properties need to be wrapped in widget key
+      const insertBrokenDirectConfig3 = {
+        op: PLUGIN_OPERATIONS.Insert,
+        id: 'new_plugin',
+        priority: 10,
+        type: DIRECT_PLUGIN,
+        RenderWidget: mockRenderWidget,
+      };
+      // missing title for iFrame Plugin
+      const insertBrokenIFrameConfig = {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'new_iframe_plugin',
+          priority: 10,
+          type: IFRAME_PLUGIN,
+          url: 'www.example_url.com',
+        },
+      };
+
+      try {
+        validatePlugin(insertBrokenDirectConfig);
+      } catch (error) {
+        expect(error.message).toBe('insert configuration is invalid for DIRECT_PLUGIN with widget id: MISSING ID');
+      }
+
+      try {
+        validatePlugin(insertBrokenDirectConfig2);
+      } catch (error) {
+        expect(error.message).toBe('insert configuration is invalid for DIRECT_PLUGIN with widget id: new_plugin');
+      }
+
+      try {
+        validatePlugin(insertBrokenDirectConfig3);
+      } catch (error) {
+        expect(error.message).toBe('plugin configuration is missing widget object');
+      }
+
+      try {
+        validatePlugin(insertBrokenIFrameConfig);
+      } catch (error) {
+        expect(error.message).toBe('insert configuration is invalid for IFRAME_PLUGIN with widget id: new_iframe_plugin');
+      }
+    });
   });
 });

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -362,7 +362,7 @@ describe('validatePlugin', () => {
       };
       expect(validatePlugin(validHideConfig)).toBe(true);
     });
-    it('returns an error if the Hidden configuration is missing a key', () => {
+    it('returns an error if the Hidden operation is configured incorrectly', () => {
       const invalidHideConfig = {
         op: PLUGIN_OPERATIONS.Hide,
       };
@@ -370,38 +370,70 @@ describe('validatePlugin', () => {
       try {
         validatePlugin(invalidHideConfig);
       } catch (error) {
-        expect(error.message).toBe('the Hide operation is missing a widgetId');
+        expect(error.message).toBe('the hide operation is missing a widgetId');
       }
     });
   });
   describe('modify plugin configuration', () => {
-    const validModifyConfig = {
-      op: PLUGIN_OPERATIONS.Modify,
-      widgetId: 'random_plugin',
-      fn: mockModifyWidget,
-    };
-    const invalidModifyConfig1 = {
-      op: PLUGIN_OPERATIONS.Modify,
-      widgetId: 'random_plugin',
-    };
-    const invalidModifyConfig2 = {
-      op: PLUGIN_OPERATIONS.Modify,
-      fn: mockModifyWidget,
-    };
+    it('returns true if the Modify operation is configured correctly', () => {
+      const validModifyConfig = {
+        op: PLUGIN_OPERATIONS.Modify,
+        widgetId: 'random_plugin',
+        fn: mockModifyWidget,
+      };
+      expect(validatePlugin(validModifyConfig)).toBe(true);
+    });
+    it('returns an error if the Modify operation is configured incorrectly', () => {
+      const invalidModifyConfig1 = {
+        op: PLUGIN_OPERATIONS.Modify,
+        widgetId: 'random_plugin',
+      };
+      const invalidModifyConfig2 = {
+        op: PLUGIN_OPERATIONS.Modify,
+        fn: mockModifyWidget,
+      };
 
-    expect(validatePlugin(validModifyConfig)).toBe(true);
-    try {
-      validatePlugin(invalidModifyConfig1);
-    } catch (error) {
-      expect(error.message).toBe('modify configuration is invalid for widget id: random_plugin');
-    }
-    try {
-      validatePlugin(invalidModifyConfig2);
-    } catch (error) {
-      expect(error.message).toBe('modify configuration is invalid for widget id: MISSING ID');
-    }
+      try {
+        validatePlugin(invalidModifyConfig1);
+      } catch (error) {
+        expect(error.message).toBe('the modify configuration is invalid for widget id: random_plugin');
+      }
+      try {
+        validatePlugin(invalidModifyConfig2);
+      } catch (error) {
+        expect(error.message).toBe('the modify configuration is invalid for widget id: MISSING ID');
+      }
+    });
   });
   describe('wrap plugin configuration', () => {
+    it('returns true if the Wrap operation is configured correctly', () => {
+      const validWrapConfig = {
+        op: PLUGIN_OPERATIONS.Wrap,
+        widgetId: 'random_plugin',
+        wrapper: mockElementWrapper,
+      };
+      expect(validatePlugin(validWrapConfig)).toBe(true);
+    });
+    it('returns an error if the Wrap operation is configured incorrectly', () => {
+      const invalidWrapConfig1 = {
+        op: PLUGIN_OPERATIONS.Wrap,
+        widgetId: 'random_plugin',
+      };
+      const invalidWrapConfig2 = {
+        op: PLUGIN_OPERATIONS.Wrap,
+        wrapper: mockElementWrapper,
+      };
 
+      try {
+        validatePlugin(invalidWrapConfig1);
+      } catch (error) {
+        expect(error.message).toBe('the wrap configuration is invalid for widget id: random_plugin');
+      }
+      try {
+        validatePlugin(invalidWrapConfig2);
+      } catch (error) {
+        expect(error.message).toBe('the wrap configuration is invalid for widget id: MISSING ID');
+      }
+    });
   });
 });

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -251,7 +251,7 @@ describe('getConfigSlots', () => {
 });
 
 describe('validatePlugin', () => {
-  describe('insert plugin', () => {
+  describe('insert plugin configuration', () => {
     it('returns true if the plugin config is correctly configured', () => {
       const insertDirectConfig = {
         op: PLUGIN_OPERATIONS.Insert,
@@ -353,5 +353,55 @@ describe('validatePlugin', () => {
         expect(error.message).toBe('insert configuration is invalid for IFRAME_PLUGIN with widget id: new_iframe_plugin');
       }
     });
+  });
+  describe('hide plugin configuration', () => {
+    it('returns true if the Hidden operation is configured', () => {
+      const validHideConfig = {
+        op: PLUGIN_OPERATIONS.Hide,
+        widgetId: 'default_content',
+      };
+      expect(validatePlugin(validHideConfig)).toBe(true);
+    });
+    it('returns an error if the Hidden configuration is missing a key', () => {
+      const invalidHideConfig = {
+        op: PLUGIN_OPERATIONS.Hide,
+      };
+
+      try {
+        validatePlugin(invalidHideConfig);
+      } catch (error) {
+        expect(error.message).toBe('the Hide operation is missing a widgetId');
+      }
+    });
+  });
+  describe('modify plugin configuration', () => {
+    const validModifyConfig = {
+      op: PLUGIN_OPERATIONS.Modify,
+      widgetId: 'random_plugin',
+      fn: mockModifyWidget,
+    };
+    const invalidModifyConfig1 = {
+      op: PLUGIN_OPERATIONS.Modify,
+      widgetId: 'random_plugin',
+    };
+    const invalidModifyConfig2 = {
+      op: PLUGIN_OPERATIONS.Modify,
+      fn: mockModifyWidget,
+    };
+
+    expect(validatePlugin(validModifyConfig)).toBe(true);
+    try {
+      validatePlugin(invalidModifyConfig1);
+    } catch (error) {
+      expect(error.message).toBe('modify configuration is invalid for widget id: random_plugin');
+    }
+    try {
+      validatePlugin(invalidModifyConfig2);
+    } catch (error) {
+      expect(error.message).toBe('modify configuration is invalid for widget id: MISSING ID');
+    }
+  });
+  describe('wrap plugin configuration', () => {
+
   });
 });


### PR DESCRIPTION
This PR is to add validation to the Plugin Operations (Insert, Hide, Modify, Wrap), as well as refactoring the error handling in the PluginSlot flow. 

Tests were also updated in the library to use the current format of Plugin configs.