### PR TITLE
feat: pass `pluginProps` to wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,9 +273,6 @@ one wrap operation. Each wrapper function takes in a ``component``, ``id`` and `
     {
       op: PLUGIN_OPERATIONS.Wrap,
       widgetId: 'default_contents',
-      pluginProps: {
-        prop1: 'prop1',
-      },
       wrapper: wrapWidget,
     }
 

--- a/README.rst
+++ b/README.rst
@@ -251,15 +251,16 @@ Wrap
 ''''
 
 Unlike Modify, the Wrap operation adds a React component around the widget, and a single widget can receive more than
-one wrap operation. Each wrapper function takes in a ``component`` and ``id`` prop.
+one wrap operation. Each wrapper function takes in a ``component``, ``id`` and ``pluginProps`` prop.
 
   .. code-block::
 
-    const wrapWidget = ({ component, idx }) => (
+    const wrapWidget = ({ component, idx, pluginProps }) => (
       <div className="bg-warning" data-testid={`wrapper${idx + 1}`} key={idx}>
         <p>This is a wrapper component that is placed around the widget.</p>
         {component}
         <p>With this wrapper, you can add anything before or after the widget.</p>
+        <p>You can use the pluginProps to pass in any additional props to the wrapper: {pluginProps.prop1}</p>
       </div>
     );
 
@@ -272,6 +273,9 @@ one wrap operation. Each wrapper function takes in a ``component`` and ``id`` pr
     {
       op: PLUGIN_OPERATIONS.Wrap,
       widgetId: 'default_contents',
+      pluginProps: {
+        prop1: 'prop1',
+      },
       wrapper: wrapWidget,
     }
 

--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -93,6 +93,7 @@ function BasePluginSlot({
             wrapComponent(
               () => container,
               pluginConfig.wrappers,
+              pluginProps,
             ),
           );
         } else {

--- a/src/plugins/PluginSlot.test.jsx
+++ b/src/plugins/PluginSlot.test.jsx
@@ -186,8 +186,8 @@ describe('PluginSlot', () => {
           wrapper: ({ component, pluginProps }) => (
             <div data-testid="custom-wrapper">
               {component}
-              <div data-testid="custom-wrapper-prop">
-                {pluginProps.prop1}
+              <div data-testid="custom-wrapper-props">
+                {pluginProps?.prop1 && `This is a wrapper with ${pluginProps?.prop1}.`}
               </div>
             </div>
           ),
@@ -200,8 +200,35 @@ describe('PluginSlot', () => {
     const customWrapper = getByTestId('custom-wrapper');
     const defaultContent = getByTestId('default_contents');
     expect(customWrapper).toContainElement(defaultContent);
-    const pluginProps = within(customWrapper).getByTestId('custom-wrapper-prop');
-    expect(pluginProps).toHaveTextContent('prop1');
+    const pluginProps = within(customWrapper).getByTestId('custom-wrapper-props');
+    expect(pluginProps).toHaveTextContent('This is a wrapper with prop1.');
+  });
+
+  it('should wrap a Plugin when using the "wrap" operation without passing props', () => {
+    usePluginSlot.mockReturnValueOnce({
+      plugins: [
+        {
+          op: PLUGIN_OPERATIONS.Wrap,
+          widgetId: 'default_contents',
+          wrapper: ({ component, pluginProps }) => (
+            <div data-testid="custom-wrapper">
+              {component}
+              <div data-testid="custom-wrapper-no-props">
+                {`This is a wrapper without props: ${JSON.stringify(pluginProps)}`}
+              </div>
+            </div>
+          ),
+        },
+      ],
+      keepDefault: true,
+    });
+
+    const { getByTestId } = render(<TestPluginSlot />);
+    const customWrapper = getByTestId('custom-wrapper');
+    const defaultContent = getByTestId('default_contents');
+    expect(customWrapper).toContainElement(defaultContent);
+    const pluginProps = within(customWrapper).getByTestId('custom-wrapper-no-props');
+    expect(pluginProps).toHaveTextContent('This is a wrapper without props: {}');
   });
 
   it('should not render a widget if the Hide operation is applied to it', () => {

--- a/src/plugins/PluginSlot.test.jsx
+++ b/src/plugins/PluginSlot.test.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import classNames from 'classnames';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { logError } from '@edx/frontend-platform/logging';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
@@ -78,7 +78,7 @@ function DefaultContents({ className, onClick, ...rest }) {
   );
 }
 
-function PluginSlotWrapper({ slotOptions, children }) {
+function PluginSlotWrapper({ slotOptions, children, pluginProps }) {
   return (
     <IntlProvider locale="en">
       <PluginSlot
@@ -86,6 +86,7 @@ function PluginSlotWrapper({ slotOptions, children }) {
         data-testid="test-slot-id"
         as="div"
         slotOptions={slotOptions}
+        pluginProps={pluginProps}
       >
         {children}
       </PluginSlot>
@@ -182,9 +183,12 @@ describe('PluginSlot', () => {
         {
           op: PLUGIN_OPERATIONS.Wrap,
           widgetId: 'default_contents',
-          wrapper: ({ component }) => (
+          wrapper: ({ component, pluginProps }) => (
             <div data-testid="custom-wrapper">
               {component}
+              <div data-testid="custom-wrapper-prop">
+                {pluginProps.prop1}
+              </div>
             </div>
           ),
         },
@@ -192,10 +196,12 @@ describe('PluginSlot', () => {
       keepDefault: true,
     });
 
-    const { getByTestId } = render(<TestPluginSlot />);
+    const { getByTestId } = render(<TestPluginSlot pluginProps={{ prop1: 'prop1' }} />);
     const customWrapper = getByTestId('custom-wrapper');
     const defaultContent = getByTestId('default_contents');
     expect(customWrapper).toContainElement(defaultContent);
+    const pluginProps = within(customWrapper).getByTestId('custom-wrapper-prop');
+    expect(pluginProps).toHaveTextContent('prop1');
   });
 
   it('should not render a widget if the Hide operation is applied to it', () => {

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -82,7 +82,7 @@ export const organizePlugins = (defaultContents, plugins) => {
  *
  * @param {Function} renderComponent - Function that returns JSX (i.e. React Component)
  * @param {Array} wrappers - Array of components that each use a "component" prop to render the wrapped contents
- * @params {object} pluginProps - Props defined in the PluginSlot
+ * @param {object} pluginProps - Props defined in the PluginSlot
  * @returns {React.ReactElement} - The plugin component wrapped by any number of wrappers provided.
 */
 export const wrapComponent = (renderComponent, wrappers, pluginProps) => wrappers.reduce(

--- a/src/plugins/data/utils.jsx
+++ b/src/plugins/data/utils.jsx
@@ -82,13 +82,14 @@ export const organizePlugins = (defaultContents, plugins) => {
  *
  * @param {Function} renderComponent - Function that returns JSX (i.e. React Component)
  * @param {Array} wrappers - Array of components that each use a "component" prop to render the wrapped contents
+ * @params {object} pluginProps - Props defined in the PluginSlot
  * @returns {React.ReactElement} - The plugin component wrapped by any number of wrappers provided.
 */
-export const wrapComponent = (renderComponent, wrappers) => wrappers.reduce(
+export const wrapComponent = (renderComponent, wrappers, pluginProps) => wrappers.reduce(
   // Disabled lint because currently we don't have a unique identifier for this
   // The "component" and "wrapper" are both functions
   // eslint-disable-next-line react/no-array-index-key
-  (component, wrapper, idx) => React.createElement(wrapper, { component, key: idx }),
+  (component, wrapper, idx) => React.createElement(wrapper, { component, key: idx, pluginProps }),
   renderComponent(),
 );
 

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -22,10 +22,10 @@ const mockIsAdminWrapper = ({ widget }) => {
   return isAdmin ? widget : null;
 };
 
-const makeMockElementWrapper = (testId = 0) => function MockElementWrapper({ component }) {
+const makeMockElementWrapper = (testId = 0) => function MockElementWrapper({ component, pluginProps }) {
   return (
     <div data-testid={`wrapper${testId}`}>
-      This is a wrapper.
+      This is a wrapper with {pluginProps?.prop1}.
       {component}
     </div>
   );
@@ -181,7 +181,7 @@ describe('organizePlugins', () => {
 describe('wrapComponent', () => {
   describe('when provided with a single wrapper in an array', () => {
     it('should wrap the provided component', () => {
-      const wrappedComponent = wrapComponent(mockRenderWidget, [makeMockElementWrapper()]);
+      const wrappedComponent = wrapComponent(mockRenderWidget, [makeMockElementWrapper()], { prop1: 'prop1' });
 
       const { getByTestId } = render(wrappedComponent);
 
@@ -189,6 +189,7 @@ describe('wrapComponent', () => {
       const widget = getByTestId('widget');
 
       expect(wrapper).toContainElement(widget);
+      expect(wrapper).toHaveTextContent('This is a wrapper with prop1.');
     });
   });
   describe('when provided with multiple wrappers in an array', () => {

--- a/src/plugins/data/utils.test.jsx
+++ b/src/plugins/data/utils.test.jsx
@@ -25,7 +25,7 @@ const mockIsAdminWrapper = ({ widget }) => {
 const makeMockElementWrapper = (testId = 0) => function MockElementWrapper({ component, pluginProps }) {
   return (
     <div data-testid={`wrapper${testId}`}>
-      This is a wrapper with {pluginProps?.prop1}.
+      {pluginProps?.prop1 && `This is a wrapper with ${pluginProps?.prop1}.`}
       {component}
     </div>
   );
@@ -190,6 +190,18 @@ describe('wrapComponent', () => {
 
       expect(wrapper).toContainElement(widget);
       expect(wrapper).toHaveTextContent('This is a wrapper with prop1.');
+    });
+
+    it('should wrap the provided component without passing props', () => {
+      const wrappedComponent = wrapComponent(mockRenderWidget, [makeMockElementWrapper()]);
+
+      const { getByTestId } = render(wrappedComponent);
+
+      const wrapper = getByTestId('wrapper0');
+      const widget = getByTestId('widget');
+
+      expect(wrapper).toContainElement(widget);
+      expect(wrapper).not.toHaveTextContent('This is a wrapper with prop1.');
     });
   });
   describe('when provided with multiple wrappers in an array', () => {


### PR DESCRIPTION
## Description

In this PR, we add support to read the `pluginProps` using the `PLUGIN_OPERATIONS.Wrap` operation. This gives us more flexibility while using plugins, allowing the wrapper component to receive context from the `PluginSlot`.

There is a practical use here: https://github.com/openedx/frontend-plugin-aspects/pull/115

## Additional Information

- Related to https://github.com/openedx/frontend-app-authoring/issues/2639

## Testing Instructions

- Check https://github.com/openedx/frontend-app-authoring/pull/2827

---
Private ref: [FAL-4299](https://tasks.opencraft.com/browse/FAL-4299)